### PR TITLE
Add JS syntax highlighting to README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ http://jdavidberger.github.io/js2glsl-shadertoy/
 - [CoffeeScript Basic Example](http://jdavidberger.github.io/js2glsl-shadertoy/#9c88c6ec1f4f964d1e96)
 
 # Basic Example
-````
+````javascript
 var js2glsl = require('js2glsl'); 
 
 function VertexPosition() {
@@ -39,7 +39,7 @@ console.log(shaderSrc.fragment);
 ````
 
 # Object-Oriented Example
-````
+````javascript
 var js2glsl = require('js2glsl'); 
 
 var shaderSpec = new js2glsl.ShaderSpecification();


### PR DESCRIPTION
This is a crazy small change, it just adds inline syntax highlighting to the README.md. Only reason to do so is to make it a little easier to grok.
